### PR TITLE
Fix CMake Boost across all versions

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -24,15 +24,21 @@ jobs:
           packages: libcurl4-openssl-dev libcrypto++-dev ninja-build
 
       - name: Install boost
-        uses: MarkusJx/install-boost@v2.4.1
+        uses: MarkusJx/install-boost@v2.4.5
         id: install-boost
         with:
           # REQUIRED: Specify the required boost version
           # A list of supported versions can be found here:
           # https://github.com/MarkusJx/prebuilt-boost/blob/main/versions-manifest.json
-          boost_version: 1.81.0
+          boost_version: 1.83.0
           # OPTIONAL: Specify a platform version
           platform_version: 22.04
+
+      - name: Dump Tooling Versions
+        run: |
+          clang++ --version
+          cmake --version
+          ninja --version
 
       - name: Configure CMake
         run: cmake -B ${{github.workspace}}/build/clang_${{env.BUILD_TYPE}} -G"Ninja" -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DCMAKE_CXX_FLAGS="-stdlib=libc++" -DROAR_BUILD_TESTS=on -DCMAKE_CXX_EXTENSIONS=on -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang -DCMAKE_LINKER=lld -DCMAKE_CXX_STANDARD=20
@@ -56,13 +62,13 @@ jobs:
           packages: libcurl4-openssl-dev libcrypto++-dev ninja-build
 
       - name: Install boost
-        uses: MarkusJx/install-boost@v2.4.1
+        uses: MarkusJx/install-boost@v2.4.5
         id: install-boost
         with:
           # REQUIRED: Specify the required boost version
           # A list of supported versions can be found here:
           # https://github.com/MarkusJx/prebuilt-boost/blob/main/versions-manifest.json
-          boost_version: 1.81.0
+          boost_version: 1.83.0
           # OPTIONAL: Specify a platform version
           platform_version: 20.04
 

--- a/cmake/dependencies/boost.cmake
+++ b/cmake/dependencies/boost.cmake
@@ -1,4 +1,4 @@
-if (CMAKE_VERSION VERSION_LESS "3.29.0")
+if (CMAKE_VERSION VERSION_LESS "3.30")
     find_package(Boost 1.81.0 REQUIRED COMPONENTS system)
 else()
     find_package(Boost CONFIG 1.81.0 REQUIRED COMPONENTS system)

--- a/cmake/dependencies/xhawk18_promise.cmake
+++ b/cmake/dependencies/xhawk18_promise.cmake
@@ -3,7 +3,7 @@ set(PROMISE_MULTITHREAD on CACHE BOOL "Promise multithreading on")
 
 option(ROAR_EXTERNAL_PROMISE "Use an external promise library (provide it manually)" OFF)
 set(ROAR_PROMISE_GIT_REPOSITORY "https://github.com/5cript/promise-cpp.git" CACHE STRING "The URL from which to clone the promiselib repository")
-set(ROAR_PROMISE_GIT_TAG "dfec4c3b579d721a85eb594484c5e4417977a030" CACHE STRING "The git tag or commit hash to checkout from the promiselib repository")
+set(ROAR_PROMISE_GIT_TAG "bfad5bdd58f29465741858d826338e5b4ca65826" CACHE STRING "The git tag or commit hash to checkout from the promiselib repository")
 
 if (ROAR_EXTERNAL_PROMISE)
 else()


### PR DESCRIPTION
Cmake 3.30 booted the find_package script for boost.